### PR TITLE
chore: tests must not depend on external web server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,12 @@
             <version>${assertj-core.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>2.1.7</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
fix gravitee-io/issues#150
