### PR TITLE
fix: Sometimes some tests using a wiremock server are failing in timeout

### DIFF
--- a/src/test/java/io/gravitee/fetcher/http/HttpFetcherTest.java
+++ b/src/test/java/io/gravitee/fetcher/http/HttpFetcherTest.java
@@ -18,6 +18,7 @@ package io.gravitee.fetcher.http;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.gravitee.fetcher.api.FetcherException;
 import io.vertx.core.Vertx;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -37,8 +38,8 @@ import static org.assertj.core.api.Assertions.fail;
  */
 public class HttpFetcherTest {
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
+    @ClassRule
+    public static final WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
     @Test
     public void shouldGetExistingFile() throws Exception {


### PR DESCRIPTION
fix gravitee-io/issues#2358