### PR TITLE
Change requestURI in HttpClient request to the relative URI

### DIFF
--- a/src/main/java/io/gravitee/fetcher/http/HttpFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/http/HttpFetcher.java
@@ -137,7 +137,7 @@ public class HttpFetcher implements Fetcher {
                     HttpMethod.GET,
                     port,
                     requestUri.getHost(),
-                    requestUri.toString()
+                    requestUri.getPath()
             );
 
             request.setTimeout(httpClientTimeout);


### PR DESCRIPTION
According to HttpClient documentation, request should be invoked with the relative URI
https://vertx.io/docs/apidocs/io/vertx/core/http/HttpClient.html#request-io.vertx.core.http.HttpMethod-int-java.lang.String-java.lang.String-

fix gravitee-io/issues#2380