### PR TITLE
fix(http): Use relative URI instead of the absolute since host and po…

### DIFF
--- a/src/main/java/io/gravitee/fetcher/http/HttpFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/http/HttpFetcher.java
@@ -133,11 +133,14 @@ public class HttpFetcher implements Fetcher {
                 (HTTPS_SCHEME.equals(requestUri.getScheme()) ? 443 : 80);
 
         try {
+            String relativeUri = (requestUri.getRawQuery() == null) ? requestUri.getRawPath() :
+                    requestUri.getRawPath() + '?' + requestUri.getRawQuery();
+
             HttpClientRequest request = httpClient.request(
                     HttpMethod.GET,
                     port,
                     requestUri.getHost(),
-                    requestUri.toString()
+                    relativeUri
             );
 
             request.setTimeout(httpClientTimeout);


### PR DESCRIPTION
…rt are settled by default at the client level.

Closes gravitee-io/issues#2380