### PR TITLE
Remove wiremock from final ZIP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
                     <artifactId>guava</artifactId>
                 </exclusion>
             </exclusions>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
**Issue**

N/A

**Description**

Remove wiremock from final ZIP
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1-clean-up-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/fetcher/gravitee-fetcher-http/2.0.1-clean-up-dependencies-SNAPSHOT/gravitee-fetcher-http-2.0.1-clean-up-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
