### PR TITLE
feat: improve fetchCron field

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -9,19 +9,27 @@
         },
         "useSystemProxy": {
             "title": "Use system proxy",
-            "description": "Use the system proxy configured by your administrator.",
+            "description": "Use the system proxy configured by your administrator",
             "type": "boolean"
         },
         "autoFetch": {
-            "title": "Auto Fetch",
-            "description": "Trigger periodic update",
+            "title": "Enable Auto Fetch",
+            "description": "Enable a periodic update of this documentation page",
             "type": "boolean",
             "default": false
         },
         "fetchCron": {
             "title": "Update frequency",
-            "description": "Define update frequency using Crontab pattern. Note: Platform administrator may have configure a max frequency that you cannot exceed.",
-            "type": "string"
+            "description": "Define update frequency using Crontab pattern. Note: Platform administrator may have configured a max frequency that you cannot exceed.",
+            "type": "string",
+            "format": "gio-cron",
+            "gioConfig": {
+                "displayIf": {
+                    "$eq": {
+                        "value.autoFetch": true
+                    }
+                }
+            }
         }
     },
     "required": ["url"],


### PR DESCRIPTION
**Issue**

N/A

**Description**

Improve fetch-cron field. Display using gio-cron and only if auto-fetch is true


![image](https://github.com/user-attachments/assets/f4a95882-a0e1-4d47-89dc-4e81a510edba)

![image](https://github.com/user-attachments/assets/3c66ea0c-bdcd-4fc7-888f-e9e3eac7d791)

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-adapt-schema-form-for-particles-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/fetcher/gravitee-fetcher-http/2.1.0-adapt-schema-form-for-particles-SNAPSHOT/gravitee-fetcher-http-2.1.0-adapt-schema-form-for-particles-SNAPSHOT.zip)
  <!-- Version placeholder end -->
